### PR TITLE
Support remount damaged volumes during csi-node restart or upgrade

### DIFF
--- a/build/start.sh
+++ b/build/start.sh
@@ -6,4 +6,5 @@ echo "KUBE_NODE_NAME:"${KUBE_NODE_NAME}
 echo "DRIVER_NAME:"${DRIVER_NAME}
 echo "KUBE_CONFIG:"${KUBE_CONFIG}
 echo "REMOUNT_DAMAGED:"${REMOUNT_DAMAGED:-false}
-/cfs/bin/cfs-csi-driver -v=${LOG_LEVEL} --endpoint=${CSI_ENDPOINT} --nodeid=${KUBE_NODE_NAME} --drivername=${DRIVER_NAME} --kubeconfig=${KUBE_CONFIG} --remountdamaged=${REMOUNT_DAMAGED:-false}> /cfs/logs/cfs-driver.out 2>&1
+echo "KUBELET_ROOT_DIR:"${KUBELET_ROOT_DIR:-/var/lib/kubelet}
+/cfs/bin/cfs-csi-driver -v=${LOG_LEVEL} --endpoint=${CSI_ENDPOINT} --nodeid=${KUBE_NODE_NAME} --drivername=${DRIVER_NAME} --kubeconfig=${KUBE_CONFIG} --remountdamaged=${REMOUNT_DAMAGED:-false} --kubeletrootdir=${KUBELET_ROOT_DIR:-/var/lib/kubelet} > /cfs/logs/cfs-driver.out 2>&1

--- a/build/start.sh
+++ b/build/start.sh
@@ -5,4 +5,5 @@ echo "CSI_ENDPOINT:"${CSI_ENDPOINT}
 echo "KUBE_NODE_NAME:"${KUBE_NODE_NAME}
 echo "DRIVER_NAME:"${DRIVER_NAME}
 echo "KUBE_CONFIG:"${KUBE_CONFIG}
-/cfs/bin/cfs-csi-driver -v=${LOG_LEVEL} --endpoint=${CSI_ENDPOINT} --nodeid=${KUBE_NODE_NAME} --drivername=${DRIVER_NAME} --kubeconfig=${KUBE_CONFIG} > /cfs/logs/cfs-driver.out 2>&1
+echo "REMOUNT_DAMAGED:"${REMOUNT_DAMAGED:-false}
+/cfs/bin/cfs-csi-driver -v=${LOG_LEVEL} --endpoint=${CSI_ENDPOINT} --nodeid=${KUBE_NODE_NAME} --drivername=${DRIVER_NAME} --kubeconfig=${KUBE_CONFIG} --remountdamaged=${REMOUNT_DAMAGED:-false}> /cfs/logs/cfs-driver.out 2>&1

--- a/cmd/chubaofs.go
+++ b/cmd/chubaofs.go
@@ -57,6 +57,7 @@ func main() {
 	cmd.PersistentFlags().StringVar(&conf.KubeConfig, "kubeconfig", "", "Kubernetes config")
 	cmd.PersistentFlags().BoolVar(&conf.RemountDamaged, "remountdamaged", false,
 		"Try to remount all the volumes damaged during csi-node restart or upgrade, set mountPropagation of pod to HostToContainer to use this feature")
+	cmd.PersistentFlags().StringVar(&conf.KubeletRootDir, "kubeletrootdir", "/var/lib/kubelet", "The path of your kubelet root dir, set it if you customized it")
 
 	if err := cmd.Execute(); err != nil {
 		glog.Errorf("cmd.Execute error:%v\n", err)

--- a/cmd/chubaofs.go
+++ b/cmd/chubaofs.go
@@ -29,12 +29,9 @@ import (
 )
 
 var (
-	endpoint       string
-	nodeID         string
-	driverName     string
-	version        = "1.0.0"
-	kubeconfig     string
-	remountDamaged bool
+	endpoint string
+	version  = "1.0.0"
+	conf     chubaofs.Config
 )
 
 func init() {
@@ -53,12 +50,12 @@ func main() {
 	}
 
 	cmd.Flags().AddGoFlagSet(flag.CommandLine)
-	cmd.PersistentFlags().StringVar(&nodeID, "nodeid", "", "This node's ID")
+	cmd.PersistentFlags().StringVar(&conf.NodeID, "nodeid", "", "This node's ID")
 	cmd.PersistentFlags().StringVar(&endpoint, "endpoint", "unix:///csi/csi.sock", "CSI endpoint, must be a UNIX socket")
-	cmd.PersistentFlags().StringVar(&driverName, "drivername", chubaofs.DriverName, "name of the driver (Kubernetes: `provisioner` field in StorageClass must correspond to this value)")
-	cmd.PersistentFlags().StringVar(&version, "version", version, "Driver version")
-	cmd.PersistentFlags().StringVar(&kubeconfig, "kubeconfig", "", "Kubernetes config")
-	cmd.PersistentFlags().BoolVar(&remountDamaged, "remountdamaged", false,
+	cmd.PersistentFlags().StringVar(&conf.DriverName, "drivername", chubaofs.DriverName, "name of the driver (Kubernetes: `provisioner` field in StorageClass must correspond to this value)")
+	cmd.PersistentFlags().StringVar(&conf.Version, "version", version, "Driver version")
+	cmd.PersistentFlags().StringVar(&conf.KubeConfig, "kubeconfig", "", "Kubernetes config")
+	cmd.PersistentFlags().BoolVar(&conf.RemountDamaged, "remountdamaged", false,
 		"Try to remount all the volumes damaged during csi-node restart or upgrade, set mountPropagation of pod to HostToContainer to use this feature")
 
 	if err := cmd.Execute(); err != nil {
@@ -70,7 +67,7 @@ func main() {
 }
 
 func handle() {
-	d, err := chubaofs.NewDriver(driverName, version, nodeID, kubeconfig, remountDamaged)
+	d, err := chubaofs.NewDriver(conf)
 	if err != nil {
 		glog.Errorf("chubaofs.NewDriver error:%v\n", err)
 		os.Exit(1)

--- a/deploy/csi-rbac.yaml
+++ b/deploy/csi-rbac.yaml
@@ -26,7 +26,7 @@ metadata:
   namespace: default
 rules:
   - apiGroups: [""]
-    resources: ["nodes"]
+    resources: ["nodes","pods"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["secrets"]

--- a/pkg/chubaofs/driver.go
+++ b/pkg/chubaofs/driver.go
@@ -34,21 +34,29 @@ const DriverName = "csi.chubaofs.com"
 
 type driver struct {
 	*csicommon.CSIDriver
-	ids            *csicommon.DefaultIdentityServer
-	cs             *controllerServer
-	ns             *nodeServer
-	remountDamaged bool
+	ids *csicommon.DefaultIdentityServer
+	cs  *controllerServer
+	ns  *nodeServer
+	Config
 }
 
-func NewDriver(driverName, version, nodeID, kubeconfig string, remountDamaged bool) (*driver, error) {
-	glog.Infof("driverName:%v, version:%v, nodeID:%v", driverName, version, nodeID)
-	clientSet, err := initClientSet(kubeconfig)
+type Config struct {
+	NodeID         string
+	DriverName     string
+	KubeConfig     string
+	Version        string
+	RemountDamaged bool
+}
+
+func NewDriver(conf Config) (*driver, error) {
+	glog.Infof("driverName:%v, version:%v, nodeID:%v", conf.DriverName, conf.Version, conf.NodeID)
+	clientSet, err := initClientSet(conf.KubeConfig)
 	if err != nil {
-		glog.Errorf("init client-go Clientset fail. kubeconfig:%v, err:%v", kubeconfig, err)
+		glog.Errorf("init client-go Clientset fail. kubeconfig:%v, err:%v", conf.KubeConfig, err)
 		return nil, err
 	}
 
-	csiDriver := csicommon.NewCSIDriver(driverName, version, nodeID, clientSet)
+	csiDriver := csicommon.NewCSIDriver(conf.DriverName, conf.Version, conf.NodeID, clientSet)
 	if csiDriver == nil {
 		return nil, status.Error(codes.InvalidArgument, "csiDriver init fail")
 	}
@@ -67,8 +75,8 @@ func NewDriver(driverName, version, nodeID, kubeconfig string, remountDamaged bo
 		})
 
 	return &driver{
-		CSIDriver:      csiDriver,
-		remountDamaged: remountDamaged,
+		CSIDriver: csiDriver,
+		Config:    conf,
 	}, nil
 }
 
@@ -94,6 +102,7 @@ func NewNodeServer(d *driver) *nodeServer {
 	return &nodeServer{
 		DefaultNodeServer: csicommon.NewDefaultNodeServer(d.CSIDriver),
 		mounter:           mount.New(""),
+		Config:            d.Config,
 	}
 }
 
@@ -112,7 +121,7 @@ func NewControllerServer(d *driver) *controllerServer {
 
 func (d *driver) Run(endpoint string) {
 	nodeServer := NewNodeServer(d)
-	if nodeName := os.Getenv("KUBE_NODE_NAME"); d.remountDamaged && nodeName != "" {
+	if nodeName := os.Getenv("KUBE_NODE_NAME"); d.RemountDamaged && nodeName != "" {
 		nodeServer.remountDamagedVolumes(nodeName)
 	}
 

--- a/pkg/chubaofs/driver.go
+++ b/pkg/chubaofs/driver.go
@@ -46,6 +46,7 @@ type Config struct {
 	KubeConfig     string
 	Version        string
 	RemountDamaged bool
+	KubeletRootDir string
 }
 
 func NewDriver(conf Config) (*driver, error) {

--- a/pkg/chubaofs/nodeserver.go
+++ b/pkg/chubaofs/nodeserver.go
@@ -35,6 +35,7 @@ import (
 )
 
 type nodeServer struct {
+	Config
 	*csicommon.DefaultNodeServer
 	mounter mount.Interface
 	mutex   sync.RWMutex

--- a/pkg/chubaofs/nodeserver.go
+++ b/pkg/chubaofs/nodeserver.go
@@ -17,6 +17,7 @@ limitations under the License.
 package chubaofs
 
 import (
+	"fmt"
 	"os"
 	"sync"
 	"time"
@@ -28,6 +29,8 @@ import (
 	"golang.org/x/sys/unix"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/mount"
 )
 
@@ -40,6 +43,7 @@ type nodeServer struct {
 func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
 	ns.mutex.Lock()
 	defer ns.mutex.Unlock()
+
 	start := time.Now()
 	stagingTargetPath := req.GetStagingTargetPath()
 	targetPath := req.GetTargetPath()
@@ -80,46 +84,51 @@ func (ns *nodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpu
 func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {
 	ns.mutex.Lock()
 	defer ns.mutex.Unlock()
+
 	start := time.Now()
 	stagingTargetPath := req.GetStagingTargetPath()
 
-	pathExists, pathErr := mount.PathExists(stagingTargetPath)
-	corruptedMnt := mount.IsCorruptedMnt(pathErr)
-	if pathExists && !corruptedMnt {
-		duration := time.Since(start)
-		glog.Infof("NodeStageVolume already mount, stagingTargetPath:%v cost:%v", stagingTargetPath, duration)
-		return &csi.NodeStageVolumeResponse{}, nil
-	}
-
-	err := mount.CleanupMountPoint(stagingTargetPath, ns.mounter, false)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "CleanupMountPoint fail, stagingTargetPath:%v error: %v", stagingTargetPath, err)
-	}
-
-	err = createMountPoint(stagingTargetPath)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "createMountPoint fail, stagingTargetPath:%v error: %v", stagingTargetPath, err)
-	}
-
-	volumeName := req.GetVolumeId()
-	param := req.VolumeContext
-	cfsServer, err := newCfsServer(volumeName, param)
-	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "new cfs server error, %v", err)
-	}
-
-	err = cfsServer.persistClientConf(stagingTargetPath)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "persist client config file fail, error: %v", err)
-	}
-
-	if err = cfsServer.runClient(); err != nil {
-		return nil, status.Errorf(codes.Internal, "mount fail, error: %v", err)
+	if err := ns.mount(stagingTargetPath, req.GetVolumeId(), req.GetVolumeContext()); err != nil {
+		return nil, err
 	}
 
 	duration := time.Since(start)
-	glog.Infof("NodeStageVolume mount, stagingTargetPath:%v cost:%v", stagingTargetPath, duration)
+	glog.Infof("NodeStageVolume mounted, stagingTargetPath:%v cost:%v", stagingTargetPath, duration)
+
 	return &csi.NodeStageVolumeResponse{}, nil
+}
+
+func (ns *nodeServer) mount(targetPath, volumeName string, param map[string]string) error {
+
+	pathExists, pathErr := mount.PathExists(targetPath)
+	corruptedMnt := mount.IsCorruptedMnt(pathErr)
+	if pathExists && !corruptedMnt {
+		glog.Infof("volume already mounted correctly, stagingTargetPath: %v", targetPath)
+		return nil
+	}
+
+	if err := mount.CleanupMountPoint(targetPath, ns.mounter, false); err != nil {
+		return status.Errorf(codes.Internal, "CleanupMountPoint fail, stagingTargetPath: %v error: %v", targetPath, err)
+	}
+
+	if err := createMountPoint(targetPath); err != nil {
+		return status.Errorf(codes.Internal, "createMountPoint fail, stagingTargetPath: %v error: %v", targetPath, err)
+	}
+
+	cfsServer, err := newCfsServer(volumeName, param)
+	if err != nil {
+		return status.Errorf(codes.InvalidArgument, "new cfs server failed: %v", err)
+	}
+
+	if err := cfsServer.persistClientConf(targetPath); err != nil {
+		return status.Errorf(codes.Internal, "persist client config file failed: %v", err)
+	}
+
+	if err := cfsServer.runClient(); err != nil {
+		return status.Errorf(codes.Internal, "mount failed: %v", err)
+	}
+
+	return nil
 }
 
 func (ns *nodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstageVolumeRequest) (*csi.NodeUnstageVolumeResponse, error) {
@@ -233,4 +242,159 @@ func nodeGetVolumeStats(_ context.Context, volumePath string) (*csi.NodeGetVolum
 			},
 		},
 	}, nil
+}
+
+// getAttachedPVOnNode finds all persistent volume objects attached in the node and controlled by me.
+func (ns *nodeServer) getAttachedPVOnNode(nodeName string) ([]*v1.PersistentVolume, error) {
+	vaList, err := ns.Driver.ClientSet.StorageV1().VolumeAttachments().List(metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("unable to list VolumeAttachments: %v", err)
+	}
+
+	nodePVNames := make(map[string]struct{})
+	for _, va := range vaList.Items {
+		if va.Spec.NodeName != nodeName {
+			continue
+		}
+		if va.Spec.Attacher != DriverName {
+			continue
+		}
+		if !va.Status.Attached {
+			continue
+		}
+		if va.Spec.Source.PersistentVolumeName == nil {
+			continue
+		}
+
+		nodePVNames[*va.Spec.Source.PersistentVolumeName] = struct{}{}
+	}
+
+	pvList, err := ns.Driver.ClientSet.CoreV1().PersistentVolumes().List(metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("unable to list PersistentVolumes: %v", err)
+	}
+
+	nodePVs := make([]*v1.PersistentVolume, 0, len(nodePVNames))
+	for i := range pvList.Items {
+		_, exist := nodePVNames[pvList.Items[i].Name]
+		if exist {
+			nodePVs = append(nodePVs, &pvList.Items[i])
+		}
+	}
+
+	return nodePVs, nil
+}
+
+type persistentVolumeWithPods struct {
+	*v1.PersistentVolume
+	pods []*v1.Pod
+}
+
+func (p *persistentVolumeWithPods) appendPodUnique(new *v1.Pod) {
+	for _, old := range p.pods {
+		if old.UID == new.UID {
+			return
+		}
+	}
+
+	p.pods = append(p.pods, new)
+}
+
+// getAttachedPVWithPodsOnNode finds all persistent volume objects as well as the related pods in the node.
+func (ns *nodeServer) getAttachedPVWithPodsOnNode(nodeName string) ([]*persistentVolumeWithPods, error) {
+	pvs, err := ns.getAttachedPVOnNode(nodeName)
+	if err != nil {
+		return nil, fmt.Errorf("getAttachedPVOnNode faied: %v", err)
+	}
+
+	claimedPVWithPods := make(map[string]*persistentVolumeWithPods, len(pvs))
+	for _, pv := range pvs {
+		if pv.Spec.ClaimRef == nil {
+			continue
+		}
+
+		pvcKey := fmt.Sprintf("%s/%s", pv.Spec.ClaimRef.Namespace, pv.Spec.ClaimRef.Name)
+		claimedPVWithPods[pvcKey] = &persistentVolumeWithPods{
+			PersistentVolume: pv,
+		}
+	}
+
+	allPodsOnNode, err := ns.Driver.ClientSet.CoreV1().Pods("").List(metav1.ListOptions{
+		FieldSelector: "spec.nodeName=" + nodeName,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list pods failed: %v", err)
+	}
+
+	for i := range allPodsOnNode.Items {
+		pod := allPodsOnNode.Items[i]
+
+		for _, volume := range pod.Spec.Volumes {
+			if volume.PersistentVolumeClaim == nil {
+				continue
+			}
+			pvcKey := fmt.Sprintf("%s/%s", pod.Namespace, volume.PersistentVolumeClaim.ClaimName)
+			pvWithPods, ok := claimedPVWithPods[pvcKey]
+			if !ok {
+				continue
+			}
+
+			pvWithPods.appendPodUnique(&pod)
+		}
+	}
+
+	ret := make([]*persistentVolumeWithPods, 0, len(claimedPVWithPods))
+	for _, v := range claimedPVWithPods {
+		if len(v.pods) != 0 {
+			ret = append(ret, v)
+		}
+	}
+
+	return ret, nil
+}
+
+// remountDamagedVolumes try to remount all the volumes damaged during csi-node restart,
+// includes the GlobalMount per pv and BindMount per pod.
+func (ns *nodeServer) remountDamagedVolumes(nodeName string) {
+	startTime := time.Now()
+
+	pvWithPods, err := ns.getAttachedPVWithPodsOnNode(nodeName)
+	if err != nil {
+		glog.Warningf("get attached pv with pods info failed: %v\n", err)
+		return
+	}
+
+	if len(pvWithPods) == 0 {
+		return
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(len(pvWithPods))
+	for _, pvp := range pvWithPods {
+		go func(p *persistentVolumeWithPods) {
+			defer wg.Done()
+
+			// remount globalmount
+			mountPath := fmt.Sprintf("/var/lib/kubelet/plugins/kubernetes.io/csi/pv/%s/globalmount", p.Name)
+			if err := ns.mount(mountPath, p.Name, p.Spec.CSI.VolumeAttributes); err != nil {
+				glog.Warningf("remount damaged volume %q to path %q failed: %v\n", p.Name, mountPath, err)
+				return
+			}
+			glog.Infof("remount damaged volume %q to path %q succeed.", p.Name, mountPath)
+
+			// bind globalmount to pods
+			for _, pod := range p.pods {
+				bindTargetPath := fmt.Sprintf("/var/lib/kubelet/pods/%s/volumes/kubernetes.io~csi/%s/mount", pod.UID, p.Name)
+				if err := bindMount(mountPath, bindTargetPath); err != nil {
+					glog.Warningf("rebind damaged volume %q to path %q failed: %v\n", p.Name, bindTargetPath, err)
+					continue
+				}
+
+				glog.Infof("rebind damaged volume %q to path %q succeed.", p.Name, bindTargetPath)
+			}
+		}(pvp)
+	}
+	wg.Wait()
+
+	glog.Infof("remount process finished cost %d ms", time.Since(startTime).Milliseconds())
 }


### PR DESCRIPTION
Volumes mounted in pods will crash after while csi-node pod shutdown, so it's hard for csi-node daemonset to upgrade or restart, which is a common problem in fuse-like csi drivers:
https://github.com/kubernetes/kubernetes/issues/70013
https://github.com/kubernetes-sigs/blob-csi-driver/issues/115

But we can remount the pods after csi-node restarted to reduce the influence.

Note: pod **mountPropagation** needs to be **HostToContainer** to use this feature.