### PR TITLE
not mount global stage path when call NodeStageVolume

### DIFF
--- a/pkg/chubaofs/nodeserver.go
+++ b/pkg/chubaofs/nodeserver.go
@@ -105,7 +105,7 @@ func (ns *nodeServer) mount(targetPath, volumeName string, param map[string]stri
 
 	pathExists, pathErr := mount.PathExists(targetPath)
 	corruptedMnt := mount.IsCorruptedMnt(pathErr)
-	if pathExists && !corruptedMnt {
+	if pathErr != nil && pathExists && !corruptedMnt {
 		glog.Infof("volume already mounted correctly, stagingTargetPath: %v", targetPath)
 		return nil
 	}


### PR DESCRIPTION
The problem occurred in kubernetes version: v1.16. It's not not mount global stage path when call NodeStageVolume.

the stagingTargetPath created by kubelet before call NodeStageVolume. 
see: https://github.com/kubernetes/kubernetes/blob/release-1.16/pkg/volume/csi/csi_block.go#L120